### PR TITLE
Release 5.4.1+fn-26.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ maven.group = com.thecsdev
 
 # Mod properties
 mod.id          = betterstats
-mod.version     = 5.4.0
+mod.version     = 5.4.1
 mod.name        = Better Statistics Screen
 mod.description = A Minecraft mod that improves the statistics screen and makes it more useful.
 mod.author      = TheCSDev

--- a/src/main/java/com/thecsdev/betterstats/client/gui/screen/McbsSivGoalEditScreen.java
+++ b/src/main/java/com/thecsdev/betterstats/client/gui/screen/McbsSivGoalEditScreen.java
@@ -8,11 +8,16 @@ import com.thecsdev.betterstats.api.mcbs.view.statsview.StatsViewUtils;
 import com.thecsdev.betterstats.resource.BLanguage;
 import com.thecsdev.common.util.enumerations.CompassDirection;
 import com.thecsdev.commonmc.api.client.gui.TElement;
+import com.thecsdev.commonmc.api.client.gui.ctxmenu.TContextMenu;
 import com.thecsdev.commonmc.api.client.gui.label.TLabelElement;
+import com.thecsdev.commonmc.api.client.gui.misc.TTextureElement;
 import com.thecsdev.commonmc.api.client.gui.panel.TPanelElement;
+import com.thecsdev.commonmc.api.client.gui.widget.TButtonWidget;
 import com.thecsdev.commonmc.api.client.gui.widget.TScrollBarWidget;
 import com.thecsdev.commonmc.api.client.gui.widget.text.TSimpleTextFieldWidget;
+import com.thecsdev.commonmc.api.stats.IStatsProvider;
 import com.thecsdev.commonmc.resource.TLanguage;
+import com.thecsdev.commonmc.resource.TSprites;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.screens.Screen;
@@ -23,9 +28,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NonNull;
 
+import java.util.Locale;
 import java.util.NoSuchElementException;
 
 import static com.thecsdev.betterstats.api.mcbs.view.statsview.StatsViewUtils.GAP;
+import static net.minecraft.core.registries.BuiltInRegistries.STAT_TYPE;
 
 /**
  * Goal editing screen for {@link McbsSivGoal}.
@@ -71,16 +78,41 @@ public final class McbsSivGoalEditScreen extends AbstractMcbsGoalEditScreen<Mcbs
 		//stat type input
 		StatsViewUtils.initGroupLabel(el_panel, BLanguage.gui_screen_editSivGoal_statType());
 		final var in_statType = new TSimpleTextFieldWidget();
-		in_statType.setBounds(el_panel.computeNextYBounds(20, GAP));
+		in_statType.setBounds(el_panel.computeNextYBounds(20, GAP).add(0, 0, -25, 0));
 		in_statType.placeholderProperty().set(Component.literal("minecraft:used"), McbsSivGoalEditScreen.class);
 		in_statType.textProperty().set(goal.getStatType().toString(), McbsSivGoalEditScreen.class);
 		in_statType.textProperty().addChangeListener((_, _, n) -> {
 			try {
-				goal.setStatType(Identifier.parse(n));
+				goal.setStatType(Identifier.parse(n.trim().toLowerCase(Locale.ROOT)));
 				refreshPreview();
 			} catch (RuntimeException ignored) {}
 		});
 		el_panel.add(in_statType);
+
+		final var btn_statType = new TButtonWidget();
+		btn_statType.setBounds(
+				in_statType.getBounds().endX + 5,
+				in_statType.getBounds().y,
+				20,
+				in_statType.getBounds().height);
+		btn_statType.contextMenuProperty().set(_ ->
+		{
+			final var ctxMenu = new TContextMenu.Builder(getClient());
+			for(final var statType : STAT_TYPE)
+				ctxMenu.addButton(
+						IStatsProvider.getStatTypeName(statType),
+						_ -> in_statType.textProperty().set(
+								String.valueOf(STAT_TYPE.getKey(statType)),
+								McbsSivGoalEditScreen.class));
+			return ctxMenu.build();
+		},
+		McbsSivGoalEditScreen.class);
+		btn_statType.eClicked.addListener(TElement::showContextMenu);
+		el_panel.add(btn_statType);
+
+		final var ico_statType = new TTextureElement(TSprites.gui_widget_dropdownCollapsed());
+		ico_statType.setBounds(btn_statType.getBounds().add(3, 3, -6, -6));
+		el_panel.add(ico_statType);
 
 		//stat subject input
 		StatsViewUtils.initGroupLabel(el_panel, BLanguage.gui_screen_editSivGoal_statSubject());
@@ -90,7 +122,7 @@ public final class McbsSivGoalEditScreen extends AbstractMcbsGoalEditScreen<Mcbs
 		in_statSubject.textProperty().set(goal.getStatSubject().toString(), McbsSivGoalEditScreen.class);
 		in_statSubject.textProperty().addChangeListener((_, _, n) -> {
 			try {
-				goal.setStatSubject(Identifier.parse(n));
+				goal.setStatSubject(Identifier.parse(n.trim().toLowerCase(Locale.ROOT)));
 				refreshPreview();
 			} catch (RuntimeException ignored) {}
 		});

--- a/src/main/java/com/thecsdev/betterstats/mcbs/view/statsview/StatsViewBlocks.java
+++ b/src/main/java/com/thecsdev/betterstats/mcbs/view/statsview/StatsViewBlocks.java
@@ -1,13 +1,15 @@
 package com.thecsdev.betterstats.mcbs.view.statsview;
 
+import com.thecsdev.betterstats.BetterStats;
+import com.thecsdev.betterstats.api.mcbs.model.goal.McbsSivGoal;
 import com.thecsdev.betterstats.api.mcbs.view.statsview.StatsView;
 import com.thecsdev.betterstats.api.mcbs.view.statsview.StatsViewUtils;
 import com.thecsdev.betterstats.client.gui.panel.StatsPageChooser;
 import com.thecsdev.betterstats.client.gui.panel.StatsSummaryPanel;
+import com.thecsdev.betterstats.client.gui.screen.McbsSivGoalEditScreen;
 import com.thecsdev.betterstats.resource.BLanguage;
 import com.thecsdev.betterstats.resource.BSprites;
 import com.thecsdev.common.util.annotations.Virtual;
-import com.thecsdev.commonmc.api.client.gui.TElement;
 import com.thecsdev.commonmc.api.client.gui.ctxmenu.TContextMenu;
 import com.thecsdev.commonmc.api.client.gui.misc.TTextureElement;
 import com.thecsdev.commonmc.api.client.gui.tooltip.TTooltip;
@@ -21,13 +23,16 @@ import net.fabricmc.api.Environment;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.permissions.Permissions;
+import net.minecraft.stats.StatType;
 import net.minecraft.util.Util;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -36,6 +41,8 @@ import static com.thecsdev.commonmc.api.world.item.TItemUtils.getCreativeModeTab
 import static com.thecsdev.commonmc.resource.TComponent.block;
 import static com.thecsdev.commonmc.resource.TComponent.gui;
 import static java.util.Comparator.comparing;
+import static net.minecraft.core.registries.BuiltInRegistries.BLOCK;
+import static net.minecraft.core.registries.BuiltInRegistries.STAT_TYPE;
 import static net.minecraft.network.chat.Component.translatable;
 import static net.minecraft.resources.Identifier.DEFAULT_NAMESPACE;
 import static net.minecraft.resources.Identifier.fromNamespaceAndPath;
@@ -100,14 +107,15 @@ public final @ApiStatus.Internal class StatsViewBlocks extends SubjectStatsView<
 		//obtain stats instance
 		final var stats = widget.statsProperty().get();
 		assert stats != null;
-		//noinspection unchecked - context menu
-		widget.contextMenuProperty().set((Function<TElement, TContextMenu>)(Object) CTX_MENU, StatsViewBlocks.class);
+
+		//context menu
+		widget.contextMenuProperty().set(_ -> CTX_MENU.apply(context, widget), StatsViewBlocks.class);
 	}
 
 	/**
 	 * Constructs a context menu for a given {@link TBlockStatsWidget}.
 	 */
-	private static final Function<TBlockStatsWidget, TContextMenu> CTX_MENU = widget ->
+	private static final BiFunction<StatsInitContext, TBlockStatsWidget, TContextMenu> CTX_MENU = (context, widget) ->
 	{
 		//obtain the stats data and ensure it is present
 		final var stats = widget.statsProperty().get();
@@ -115,6 +123,7 @@ public final @ApiStatus.Internal class StatsViewBlocks extends SubjectStatsView<
 
 		//create the context menu builder
 		final var client  = Objects.requireNonNull(widget.getClient(), "Missing 'client' instance");
+		final var tab     = context.getTab();
 		final var builder = new TContextMenu.Builder(client);
 
 		//give command
@@ -148,6 +157,50 @@ public final @ApiStatus.Internal class StatsViewBlocks extends SubjectStatsView<
 			builder.addButton(
 					gui(BSprites.gui_icon_faviconWiki()).append(" ").append(BLanguage.gui_statsview_stats_ctxMenu_viewOnWiki()),
 					_ -> Util.getPlatform().openUri(url_wiki));
+		}
+
+		//"Create goal" button
+		if(BetterStats.getConfig().experimentsEnabled()) {
+			builder.addContextMenu(
+					gui("container/cartography_table/map").append(" ").append(BLanguage.gui_statsview_stats_ctxMenu_createGoal()),
+					_ ->
+					{
+						//sub-menu for "Create goal"
+						final var ctx_newGoal = new TContextMenu.Builder(client);
+
+						//sub-menu entry for each StatType
+						for(final var statType : STAT_TYPE)
+						{
+							//skip non-Item-related StatType-s
+							if(statType.getRegistry() != BLOCK) continue;
+							//noinspection unchecked
+							final var statTypeB = (StatType<Block>) statType;
+
+							ctx_newGoal.addButton(
+									IStatsProvider.getStatTypeName(statTypeB),
+									_ ->
+									{
+										//create and add the goal
+										final int val  = stats.getValues().getOrDefault(statTypeB.get(stats.getSubject()), 0);
+										final var goal = new McbsSivGoal(
+												Objects.requireNonNull(STAT_TYPE.getKey(statTypeB)),
+												stats.getSubjectID(),
+												val,
+												val + 64);
+										tab.putGoal(goal);
+
+										//create and open the goal's editing screen
+										final var editScreen = new McbsSivGoalEditScreen(client.gui.screen(), tab, goal);
+										client.gui.setScreen(editScreen.getAsScreen());
+
+										//in the background, switch view to goals
+										tab.setCurrentView(StatsViewGoals.INSTANCE);
+									});
+						}
+
+						//build sub-menu
+						return ctx_newGoal.build();
+					});
 		}
 
 		//close button, and then build and return a new context menu

--- a/src/main/java/com/thecsdev/betterstats/mcbs/view/statsview/StatsViewGeneral.java
+++ b/src/main/java/com/thecsdev/betterstats/mcbs/view/statsview/StatsViewGeneral.java
@@ -1,10 +1,14 @@
 package com.thecsdev.betterstats.mcbs.view.statsview;
 
+import com.thecsdev.betterstats.BetterStats;
+import com.thecsdev.betterstats.api.mcbs.model.goal.McbsSivGoal;
 import com.thecsdev.betterstats.api.mcbs.view.statsview.StatsView;
 import com.thecsdev.betterstats.api.mcbs.view.statsview.StatsViewUtils;
 import com.thecsdev.betterstats.client.gui.panel.StatsPageChooser;
+import com.thecsdev.betterstats.client.gui.screen.McbsSivGoalEditScreen;
 import com.thecsdev.betterstats.resource.BLanguage;
 import com.thecsdev.betterstats.resource.BSprites;
+import com.thecsdev.commonmc.api.client.gui.ctxmenu.TContextMenu;
 import com.thecsdev.commonmc.api.client.gui.misc.TTextureElement;
 import com.thecsdev.commonmc.api.client.gui.tooltip.TTooltip;
 import com.thecsdev.commonmc.api.client.gui.widget.TDropdownWidget;
@@ -17,16 +21,20 @@ import net.fabricmc.api.Environment;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.stats.StatFormatter;
+import net.minecraft.stats.Stats;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.thecsdev.betterstats.BetterStats.MOD_ID;
+import static com.thecsdev.commonmc.resource.TComponent.gui;
 import static com.thecsdev.commonmc.resource.TComponent.item;
 import static java.util.Comparator.comparing;
+import static net.minecraft.core.registries.BuiltInRegistries.STAT_TYPE;
 import static net.minecraft.network.chat.Component.literal;
 import static net.minecraft.network.chat.Component.translatable;
 import static net.minecraft.resources.Identifier.fromNamespaceAndPath;
@@ -92,6 +100,7 @@ public final @ApiStatus.Internal class StatsViewGeneral extends SubjectStatsView
 		//obtain stat instance
 		final var stat = widget.statProperty().get();
 		assert stat != null;
+
 		//stat formatter overrides
 		if(stat.isDistance()) {
 			final var distanceUnit = context.getFilters().getProperty(DistanceUnit.class, DistanceUnit.FID, DistanceUnit.VANILLA);
@@ -101,7 +110,54 @@ public final @ApiStatus.Internal class StatsViewGeneral extends SubjectStatsView
 			final var timeUnit = context.getFilters().getProperty(TimeUnit.class, TimeUnit.FID, TimeUnit.VANILLA);
 			widget.formatterOverrideProperty().set(timeUnit.getFormatter(), StatsViewGeneral.class);
 		}
+
+		//context menu
+		widget.contextMenuProperty().set(_ -> CTX_MENU.apply(context, widget), StatsViewGeneral.class);
 	}
+
+	/**
+	 * Constructs a context menu for a given {@link TCustomStatWidget}.
+	 */
+	private static final BiFunction<StatsInitContext, TCustomStatWidget, TContextMenu> CTX_MENU = (context, widget) ->
+	{
+		//obtain the stats data and ensure it is present
+		final var stat = widget.statProperty().get();
+		assert stat != null;
+
+		//create the context menu builder
+		final var client  = Objects.requireNonNull(widget.getClient(), "Missing 'client' instance");
+		final var tab     = context.getTab();
+		final var builder = new TContextMenu.Builder(client);
+
+		//"Create goal" button
+		if(BetterStats.getConfig().experimentsEnabled()) {
+			builder.addButton(
+					gui("container/cartography_table/map").append(" ").append(BLanguage.gui_statsview_stats_ctxMenu_createGoal()),
+					_ ->
+					{
+						//create and add the goal
+						final var goal = new McbsSivGoal(
+								Objects.requireNonNull(STAT_TYPE.getKey(Stats.CUSTOM)),
+								stat.getSubjectID(),
+								stat.getValue(),
+								stat.getValue() + 64);
+						tab.putGoal(goal);
+
+						//create and open the goal's editing screen
+						final var editScreen = new McbsSivGoalEditScreen(client.gui.screen(), tab, goal);
+						client.gui.setScreen(editScreen.getAsScreen());
+
+						//in the background, switch view to goals
+						tab.setCurrentView(StatsViewGoals.INSTANCE);
+					});
+		}
+
+		//close button, and then build and return a new context menu
+		builder.addButton(
+				gui(BSprites.gui_icon_close()).append(" ").append(BLanguage.gui_menubar_file_close()),
+				_ -> {});
+		return builder.build();
+	};
 	// --------------------------------------------------
 	protected final @Override @NotNull Comparator<CustomStat> getStatsSorter(@NotNull Filters filters) throws NullPointerException {
 		return filters.getProperty(SortBy.class, SortBy.FID, SortBy.ALPHABETICAL).getStatsSorter();

--- a/src/main/java/com/thecsdev/betterstats/mcbs/view/statsview/StatsViewItems.java
+++ b/src/main/java/com/thecsdev/betterstats/mcbs/view/statsview/StatsViewItems.java
@@ -1,13 +1,15 @@
 package com.thecsdev.betterstats.mcbs.view.statsview;
 
+import com.thecsdev.betterstats.BetterStats;
+import com.thecsdev.betterstats.api.mcbs.model.goal.McbsSivGoal;
 import com.thecsdev.betterstats.api.mcbs.view.statsview.StatsView;
 import com.thecsdev.betterstats.api.mcbs.view.statsview.StatsViewUtils;
 import com.thecsdev.betterstats.client.gui.panel.StatsPageChooser;
 import com.thecsdev.betterstats.client.gui.panel.StatsSummaryPanel;
+import com.thecsdev.betterstats.client.gui.screen.McbsSivGoalEditScreen;
 import com.thecsdev.betterstats.resource.BLanguage;
 import com.thecsdev.betterstats.resource.BSprites;
 import com.thecsdev.common.util.annotations.Virtual;
-import com.thecsdev.commonmc.api.client.gui.TElement;
 import com.thecsdev.commonmc.api.client.gui.ctxmenu.TContextMenu;
 import com.thecsdev.commonmc.api.client.gui.misc.TTextureElement;
 import com.thecsdev.commonmc.api.client.gui.tooltip.TTooltip;
@@ -21,12 +23,15 @@ import net.fabricmc.api.Environment;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.permissions.Permissions;
+import net.minecraft.stats.StatType;
 import net.minecraft.util.Util;
 import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -34,6 +39,8 @@ import static com.thecsdev.betterstats.BetterStats.MOD_ID;
 import static com.thecsdev.commonmc.api.world.item.TItemUtils.getCreativeModeTab;
 import static com.thecsdev.commonmc.resource.TComponent.*;
 import static java.util.Comparator.comparing;
+import static net.minecraft.core.registries.BuiltInRegistries.ITEM;
+import static net.minecraft.core.registries.BuiltInRegistries.STAT_TYPE;
 import static net.minecraft.network.chat.Component.translatable;
 import static net.minecraft.resources.Identifier.DEFAULT_NAMESPACE;
 import static net.minecraft.resources.Identifier.fromNamespaceAndPath;
@@ -94,18 +101,20 @@ public sealed @ApiStatus.Internal class StatsViewItems extends SubjectStatsView<
 	 * @param widget The newly created {@link TItemStatsWidget}.
 	 * @throws NullPointerException If any of the arguments is {@code null}.
 	 */
-	protected @Virtual void postProcessWidget(@NotNull StatsView.StatsInitContext context, @NotNull TItemStatsWidget widget) {
+	protected @Virtual void postProcessWidget(@NotNull StatsView.StatsInitContext context, @NotNull TItemStatsWidget widget)
+	{
 		//obtain stats instance
 		final var stats = widget.statsProperty().get();
 		assert stats != null;
-		//noinspection unchecked - context menu
-		widget.contextMenuProperty().set((Function<TElement, TContextMenu>)(Object) CTX_MENU, StatsViewItems.class);
+
+		//context menu
+		widget.contextMenuProperty().set(_ -> CTX_MENU.apply(context, widget), StatsViewItems.class);
 	}
 
 	/**
 	 * Constructs a context menu for a given {@link TItemStatsWidget}.
 	 */
-	private static final Function<TItemStatsWidget, TContextMenu> CTX_MENU = widget ->
+	private static final BiFunction<StatsInitContext, TItemStatsWidget, TContextMenu> CTX_MENU = (context, widget) ->
 	{
 		//obtain the stats data and ensure it is present
 		final var stats = widget.statsProperty().get();
@@ -113,6 +122,7 @@ public sealed @ApiStatus.Internal class StatsViewItems extends SubjectStatsView<
 
 		//create the context menu builder
 		final var client  = Objects.requireNonNull(widget.getClient(), "Missing 'client' instance");
+		final var tab     = context.getTab();
 		final var builder = new TContextMenu.Builder(client);
 
 		//give command
@@ -140,6 +150,50 @@ public sealed @ApiStatus.Internal class StatsViewItems extends SubjectStatsView<
 			builder.addButton(
 					gui(BSprites.gui_icon_faviconWiki()).append(" ").append(BLanguage.gui_statsview_stats_ctxMenu_viewOnWiki()),
 					_ -> Util.getPlatform().openUri(url_wiki));
+		}
+
+		//"Create goal" button
+		if(BetterStats.getConfig().experimentsEnabled()) {
+			builder.addContextMenu(
+					gui("container/cartography_table/map").append(" ").append(BLanguage.gui_statsview_stats_ctxMenu_createGoal()),
+					_ ->
+					{
+						//sub-menu for "Create goal"
+						final var ctx_newGoal = new TContextMenu.Builder(client);
+
+						//sub-menu entry for each StatType
+						for(final var statType : STAT_TYPE)
+						{
+							//skip non-Item-related StatType-s
+							if(statType.getRegistry() != ITEM) continue;
+							//noinspection unchecked
+							final var statTypeI = (StatType<Item>) statType;
+
+							ctx_newGoal.addButton(
+									IStatsProvider.getStatTypeName(statTypeI),
+									_ ->
+									{
+										//create and add the goal
+										final int val  = stats.getValues().getOrDefault(statTypeI.get(stats.getSubject()), 0);
+										final var goal = new McbsSivGoal(
+												Objects.requireNonNull(STAT_TYPE.getKey(statTypeI)),
+												stats.getSubjectID(),
+												val,
+												val + 64);
+										tab.putGoal(goal);
+
+										//create and open the goal's editing screen
+										final var editScreen = new McbsSivGoalEditScreen(client.gui.screen(), tab, goal);
+										client.gui.setScreen(editScreen.getAsScreen());
+
+										//in the background, switch view to goals
+										tab.setCurrentView(StatsViewGoals.INSTANCE);
+									});
+						}
+
+						//build sub-menu
+						return ctx_newGoal.build();
+					});
 		}
 
 		//close button, and then build and return a new context menu

--- a/src/main/java/com/thecsdev/betterstats/mcbs/view/statsview/StatsViewMobs.java
+++ b/src/main/java/com/thecsdev/betterstats/mcbs/view/statsview/StatsViewMobs.java
@@ -1,14 +1,15 @@
 package com.thecsdev.betterstats.mcbs.view.statsview;
 
 import com.thecsdev.betterstats.BetterStats;
+import com.thecsdev.betterstats.api.mcbs.model.goal.McbsSivGoal;
 import com.thecsdev.betterstats.api.mcbs.view.statsview.StatsView;
 import com.thecsdev.betterstats.api.mcbs.view.statsview.StatsViewUtils;
 import com.thecsdev.betterstats.client.gui.panel.StatsPageChooser;
 import com.thecsdev.betterstats.client.gui.panel.StatsSummaryPanel;
+import com.thecsdev.betterstats.client.gui.screen.McbsSivGoalEditScreen;
 import com.thecsdev.betterstats.resource.BLanguage;
 import com.thecsdev.betterstats.resource.BSprites;
 import com.thecsdev.common.util.annotations.Virtual;
-import com.thecsdev.commonmc.api.client.gui.TElement;
 import com.thecsdev.commonmc.api.client.gui.ctxmenu.TContextMenu;
 import com.thecsdev.commonmc.api.client.gui.misc.TTextureElement;
 import com.thecsdev.commonmc.api.client.gui.screen.TTextDialogScreen;
@@ -23,19 +24,24 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
+import net.minecraft.stats.StatType;
 import net.minecraft.util.Util;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.thecsdev.betterstats.BetterStats.MOD_ID;
 import static com.thecsdev.commonmc.resource.TComponent.*;
 import static java.util.Comparator.comparing;
+import static net.minecraft.core.registries.BuiltInRegistries.ENTITY_TYPE;
+import static net.minecraft.core.registries.BuiltInRegistries.STAT_TYPE;
 import static net.minecraft.network.chat.Component.literal;
 import static net.minecraft.network.chat.Component.translatable;
 import static net.minecraft.resources.Identifier.DEFAULT_NAMESPACE;
@@ -103,15 +109,16 @@ public sealed @ApiStatus.Internal class StatsViewMobs extends SubjectStatsView<E
 		//obtain stats instance
 		final var stats = widget.statsProperty().get();
 		assert stats != null;
-		//noinspection unchecked - context menu
-		widget.contextMenuProperty().set((Function<TElement, TContextMenu>)(Object) CTX_MENU, StatsViewMobs.class);
+
+		//context menu
+		widget.contextMenuProperty().set(_ -> CTX_MENU.apply(context, widget), StatsViewMobs.class);
 		widget.followsCursorProperty().set(BetterStats.getConfig().getGuiMobsFollowCursor(), StatsViewMobs.class);
 	}
 
 	/**
 	 * Constructs a context menu for a given {@link TEntityStatsWidget}.
 	 */
-	private static final Function<TEntityStatsWidget, TContextMenu> CTX_MENU = widget ->
+	private static final BiFunction<StatsInitContext, TEntityStatsWidget, TContextMenu> CTX_MENU = (context, widget) ->
 	{
 		//obtain the stats data and ensure it is present
 		final var stats = widget.statsProperty().get();
@@ -119,6 +126,7 @@ public sealed @ApiStatus.Internal class StatsViewMobs extends SubjectStatsView<E
 
 		//create the context menu builder
 		final var client  = Objects.requireNonNull(widget.getClient(), "Missing 'client' instance");
+		final var tab     = context.getTab();
 		final var builder = new TContextMenu.Builder(client);
 
 		//error information
@@ -140,6 +148,50 @@ public sealed @ApiStatus.Internal class StatsViewMobs extends SubjectStatsView<E
 			builder.addButton(
 					gui(BSprites.gui_icon_faviconWiki()).append(" ").append(BLanguage.gui_statsview_stats_ctxMenu_viewOnWiki()),
 					_ -> Util.getPlatform().openUri(url_wiki));
+		}
+
+		//"Create goal" button
+		if(BetterStats.getConfig().experimentsEnabled()) {
+			builder.addContextMenu(
+					gui("container/cartography_table/map").append(" ").append(BLanguage.gui_statsview_stats_ctxMenu_createGoal()),
+					_ ->
+					{
+						//sub-menu for "Create goal"
+						final var ctx_newGoal = new TContextMenu.Builder(client);
+
+						//sub-menu entry for each StatType
+						for(final var statType : STAT_TYPE)
+						{
+							//skip non-Item-related StatType-s
+							if(statType.getRegistry() != ENTITY_TYPE) continue;
+							//noinspection unchecked
+							final var statTypeE = (StatType<EntityType<?>>) statType;
+
+							ctx_newGoal.addButton(
+									IStatsProvider.getStatTypeName(statTypeE),
+									_ ->
+									{
+										//create and add the goal
+										final int val  = stats.getValues().getOrDefault(statTypeE.get(stats.getSubject()), 0);
+										final var goal = new McbsSivGoal(
+												Objects.requireNonNull(STAT_TYPE.getKey(statTypeE)),
+												stats.getSubjectID(),
+												val,
+												val + 64);
+										tab.putGoal(goal);
+
+										//create and open the goal's editing screen
+										final var editScreen = new McbsSivGoalEditScreen(client.gui.screen(), tab, goal);
+										client.gui.setScreen(editScreen.getAsScreen());
+
+										//in the background, switch view to goals
+										tab.setCurrentView(StatsViewGoals.INSTANCE);
+									});
+						}
+
+						//build sub-menu
+						return ctx_newGoal.build();
+					});
 		}
 
 		//close button, and then build and return a new context menu

--- a/src/main/java/com/thecsdev/betterstats/resource/BLanguage.java
+++ b/src/main/java/com/thecsdev/betterstats/resource/BLanguage.java
@@ -115,6 +115,7 @@ public final class BLanguage
 	public static final MutableComponent gui_statsview_stats_noGoals() { return translatable("betterstats.gui.statsview.stats.no_goals"); }
 	public static final MutableComponent gui_statsview_stats_ctxMenu_viewErrorInfo() { return translatable("betterstats.gui.statsview.stats.ctxmenu.view_error_info"); }
 	public static final MutableComponent gui_statsview_stats_ctxMenu_viewOnWiki() { return translatable("betterstats.gui.statsview.stats.ctxmenu.view_on_wiki"); }
+	public static final MutableComponent gui_statsview_stats_ctxMenu_createGoal() { return translatable("betterstats.gui.statsview.stats.ctxmenu.create_goal"); }
 	public static final MutableComponent gui_statsview_stats_mcbsGoals() { return translatable("betterstats.gui.statsview.mcbs_goals"); }
 	public static final MutableComponent gui_statsview_stats_mcbsGoals_alert1Prefix() { return translatable("betterstats.gui.statsview.mcbs_goals.alert1.prefix"); }
 	public static final MutableComponent gui_statsview_stats_mcbsGoals_alert1() { return translatable("betterstats.gui.statsview.mcbs_goals.alert1"); }

--- a/src/main/resources/assets/betterstats/lang/docs/index.html
+++ b/src/main/resources/assets/betterstats/lang/docs/index.html
@@ -434,6 +434,13 @@
 				article about the corresponding thing. That choise uses this textual label.
 			</div>
 			<hr>
+
+            <div>
+                <p><b>betterstats.gui.statsview.stats.ctxmenu.create_goal</b></p>
+                Right-clicking statistics about a given thing may present the user with a choice to create a "Goal" about
+                said thing.
+            </div>
+            <hr>
 			
 			<div>
 				<p><b>betterstats.gui.statsview.mcbs_goals</b></p>

--- a/src/main/resources/assets/betterstats/lang/en_us.json
+++ b/src/main/resources/assets/betterstats/lang/en_us.json
@@ -67,6 +67,7 @@
 	"betterstats.gui.statsview.stats.no_goals": "There are no goals to show yet...",
 	"betterstats.gui.statsview.stats.ctxmenu.view_error_info": "View error info",
 	"betterstats.gui.statsview.stats.ctxmenu.view_on_wiki": "View on Wiki",
+	"betterstats.gui.statsview.stats.ctxmenu.create_goal": "Create goal",
 	"betterstats.gui.statsview.mcbs_goals": "Goals",
 	"betterstats.gui.statsview.mcbs_goals.alert1.prefix": "[New ✨]",
 	"betterstats.gui.statsview.mcbs_goals.alert1": "Define custom milestones to track your progress toward specific statistical targets like resource collection.",

--- a/src/main/resources/assets/betterstats/lang/zh_cn.json
+++ b/src/main/resources/assets/betterstats/lang/zh_cn.json
@@ -67,6 +67,7 @@
 	"betterstats.gui.statsview.stats.no_goals": "There are no goals to show yet...",
 	"betterstats.gui.statsview.stats.ctxmenu.view_error_info": "View error info",
 	"betterstats.gui.statsview.stats.ctxmenu.view_on_wiki": "在 Wiki 上查看",
+	"betterstats.gui.statsview.stats.ctxmenu.create_goal": "Create goal",
 	"betterstats.gui.statsview.mcbs_goals": "Goals",
 	"betterstats.gui.statsview.mcbs_goals.alert1.prefix": "[New ✨]",
 	"betterstats.gui.statsview.mcbs_goals.alert1": "Define custom milestones to track your progress toward specific statistical targets like resource collection.",


### PR DESCRIPTION
- Added utility "Create goal" to RMB context menus of stats.
- Added utility dropdown for selecting "Stat type (Activity)" in goal edit screen.

**Note:** These serve as utilities for creating goals easier. "Goals" feature is still experimental and thus must be enabled in mod settings to use it.
